### PR TITLE
feat: token refresh for decrypted enclave downloads

### DIFF
--- a/src/contexts/record-context.tsx
+++ b/src/contexts/record-context.tsx
@@ -1029,7 +1029,12 @@ export const RecordContextProvider: React.FC<PropsWithChildren> = ({ children })
       let url = '';
       if ((isIOS() && process.env.NEXT_PUBLIC_OPTIONAL_CONVERT_PDF_SERVERSIDE) || process.env.NEXT_PUBLIC_CONVERT_PDF_SERVERSIDE) {
 
-        const tempKey = await temporaryServerEncryptionKey(dbContextRef.current!, saasContext);
+
+         const refreshResult = await dbContextRef.current?.refresh({ // we always refresh token here as we're not sure if the token is still valid or not and it's related with the serverCommunicationKey
+          refreshToken: dbContextRef.current.refreshToken
+        })
+
+        const tempKey = await temporaryServerEncryptionKey(dbContextRef.current!, saasContext, refreshResult && refreshResult.success ? refreshResult.accessToken : undefined, refreshResult && refreshResult.success ? refreshResult.serverCommunicationKey : undefined);
 
         console.log('Downloading attachment with server-side decryption');
         url =  '/enclave/download/' + attachment.storageKey + '?encr=' + encodeURIComponent(tempKey.encryptedKey) + '&klh=' + encodeURIComponent(tempKey.keyLocatorHash) + '&kh=' + encodeURIComponent(tempKey.keyHash) + '&dbid=' + encodeURIComponent(dbContextRef.current?.databaseHashId || '');

--- a/src/data/client/base-api-client.ts
+++ b/src/data/client/base-api-client.ts
@@ -89,7 +89,7 @@ export class ApiClient {
             refreshToken: this.dbContext.refreshToken
           })
           if((refreshResult)?.success) {
-            console.log('Refresh token success', this.dbContext?.accessToken);
+            console.log('Refresh token success', refreshResult.accessToken, refreshResult.serverCommunicationKey);
             return this.getArrayBuffer(endpoint, refreshResult.accessToken, temporaryKeyGenerator, refreshResult.serverCommunicationKey);
           } else {
             this.dbContext?.logout();
@@ -186,7 +186,7 @@ export class ApiClient {
             refreshToken: this.dbContext.refreshToken
           })
           if((refreshResult)?.success) {
-            console.log('Refresh token success', this.dbContext?.accessToken, this.dbContext?.serverCommunicationKey);
+            console.log('Refresh token success', refreshResult.accessToken, refreshResult.serverCommunicationKey);
             return this.request(endpoint, method, encryptionSettings, body, formData, refreshResult.accessToken, refreshResult.serverCommunicationKey);
           } else {
             this.dbContext?.logout();


### PR DESCRIPTION
This pull request introduces changes to improve token refresh handling and server communication key usage in the `RecordContextProvider` and `ApiClient` classes. The updates ensure that refreshed tokens and server communication keys are consistently passed to subsequent operations, enhancing security and reliability.

### Token Refresh Handling Updates:

* [`src/contexts/record-context.tsx`](diffhunk://#diff-027704133b1c0b490d34cdb7d02c2fe7abe7279a2e5454cca60dd7088b9b5465L1032-R1037): Updated `RecordContextProvider` to always refresh tokens before proceeding with server-side encryption key generation. The refreshed `accessToken` and `serverCommunicationKey` are now conditionally passed to `temporaryServerEncryptionKey`.

### Server Communication Key Logging and Usage:

* [`src/data/client/base-api-client.ts`](diffhunk://#diff-67345d81bebfcfdfee15109620a645d6808749ef26eba3bad3893d537c36d255L92-R92): Modified `ApiClient` to log the refreshed `accessToken` and `serverCommunicationKey` instead of relying on potentially outdated values from `dbContext`. This ensures accurate debugging information. [[1]](diffhunk://#diff-67345d81bebfcfdfee15109620a645d6808749ef26eba3bad3893d537c36d255L92-R92) [[2]](diffhunk://#diff-67345d81bebfcfdfee15109620a645d6808749ef26eba3bad3893d537c36d255L189-R189)